### PR TITLE
Vendor bootstrap SCSS assets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,5 +10,4 @@
 # rspec failure tracking
 .rspec_status
 
-
 **/*.gem

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "vendor/assets/bootstrap"]
+	path = vendor/assets/bootstrap
+	url = https://github.com/twbs/bootstrap.git

--- a/bootstrap-scss.gemspec
+++ b/bootstrap-scss.gemspec
@@ -28,11 +28,16 @@ Gem::Specification.new do |spec|
       'public gem pushes.'
   end
 
+  files = 'lib/* *.md *.gemspec *.txt vendor/assets/bootstrap/scss/*'
+
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
-  spec.files         = `git ls-files -- lib/* *.md *.gemspec *.txt Rakefile`.split("\n")
+  spec.files         = `git ls-files --recurse-submodules -- #{files}`.split("\n")
   spec.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
   spec.bindir        = 'exe'
   spec.require_paths = ['lib']
+
+  # SassC requires Ruby 2.3.3. Also specify here to make it obvious.
+  spec.required_ruby_version = '>= 2.3.3'
 
   spec.add_development_dependency 'bundler', '~> 2.2', '>= 2.2.33'
   spec.add_development_dependency 'rake', '>= 12.3.3'

--- a/lib/bootstrap/scss.rb
+++ b/lib/bootstrap/scss.rb
@@ -4,7 +4,55 @@ require 'bootstrap/scss/version'
 
 module Bootstrap
   module Scss
-    class Error < StandardError; end
-    # Your code goes here...
+    GEM_PATH = File.expand_path '..', File.dirname(__FILE__)
+    ASSETS_PATH = File.join GEM_PATH, 'vendor', 'assets'
+
+    class << self
+      def load!
+        if rails?
+          register_rails_engine
+        elsif hanami?
+          register_hanami
+        elsif sprockets?
+          register_sprockets
+        elsif defined?(::Sass) && ::Sass.respond_to?(:load_paths)
+          # The deprecated `sass` gem:
+          ::Sass.load_paths << ASSETS_PATH
+        end
+
+        if defined?(::Sass::Script::Value::Number)
+          # Set precision to 6 as per:
+          # https://github.com/twbs/bootstrap/blob/da717b03e6e72d7a61c007acb9223b9626ae5ee5/package.json#L28
+          ::Sass::Script::Value::Number.precision = [6, ::Sass::Script::Value::Number.precision].max
+        end
+      end
+
+      # Environment detection helpers
+      def sprockets?
+        defined?(::Sprockets)
+      end
+
+      def rails?
+        defined?(::Rails)
+      end
+
+      def hanami?
+        defined?(::Hanami)
+      end
+
+      private
+
+      def register_rails_engine
+        require 'bootstrap/scss/engine'
+      end
+
+      def register_sprockets
+        Sprockets.append_path ASSETS_PATH
+      end
+
+      def register_hanami
+        Hanami::Assets.sources << ASSETS_PATH
+      end
+    end
   end
 end

--- a/lib/bootstrap/scss/engine.rb
+++ b/lib/bootstrap/scss/engine.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Bootstrap
+  module Scss
+    class Engine < ::Rails::Engine
+      initializer :assets do |app|
+        app.config.assets.paths << root.join('vendor', 'assets')
+      end
+    end
+  end
+end

--- a/lib/bootstrap/scss/version.rb
+++ b/lib/bootstrap/scss/version.rb
@@ -2,6 +2,7 @@
 
 module Bootstrap
   module Scss
+    # We won't adopt bootstrap versions until we figure this gem out
     VERSION = '0.0.1'
   end
 end


### PR DESCRIPTION
This is how we'll include boostrap SCSS code in our gem.

Currently, we'll only vendor SCSS code from 5.1.x, until we figure out the project's auto-build (See #1)